### PR TITLE
Delete and sort organizations. Cleanup terraform config files

### DIFF
--- a/src/main/java/ca/bc/hlth/mohorganizations/SecurityConfig.java
+++ b/src/main/java/ca/bc/hlth/mohorganizations/SecurityConfig.java
@@ -28,6 +28,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .mvcMatchers(HttpMethod.GET, "/organizations/{resourceId}").hasRole("get-org")
                 .mvcMatchers(HttpMethod.POST, "/organizations").hasRole("add-org")
                 .mvcMatchers(HttpMethod.PUT, "/organizations/{resourceId}").hasRole("add-org")
+                .mvcMatchers(HttpMethod.DELETE, "/organizations/{resourceId}").hasRole("delete-org")
                 .mvcMatchers(HttpMethod.GET, "/health").permitAll()
                 .anyRequest().denyAll()
                 .and().cors()

--- a/terraform-dev/infrastructure/db.tf
+++ b/terraform-dev/infrastructure/db.tf
@@ -1,27 +1,3 @@
-
-resource "aws_dynamodb_table" "startup_sample_table" {
-  name           = var.db_name
-  hash_key       = "pid"
-  range_key      = "createdAt"
-  read_capacity  = 1
-  write_capacity = 1
-
-  attribute {
-    name = "pid"
-    type = "S"
-  }
-
-  attribute {
-    name = "createdAt"
-    type = "S"
-  }
-
-  tags = local.common_tags
-}
-
-
-## TODO: Document this.
-
 resource "aws_dynamodb_table" "organization_table" {
   name           = "Organization"
   hash_key       = "id"
@@ -34,5 +10,3 @@ resource "aws_dynamodb_table" "organization_table" {
   }
 
 }
-
-## END TODO

--- a/terraform-dev/infrastructure/roles.tf
+++ b/terraform-dev/infrastructure/roles.tf
@@ -124,38 +124,6 @@ resource "aws_iam_role_policy" "ssp_bucket_policy" {
 }
 
 
-resource "aws_iam_role_policy" "dynamodb_sample_table_role_policy" {
-  name = "dynamodb_sample_table_role_policy"
-  role = aws_iam_role.organizations_api_container_role.id
-
-  policy = jsonencode(
-  {
-    "Version": "2012-10-17",
-    "Statement": [
-      {
-          "Effect": "Allow",
-          "Action": [
-              "dynamodb:BatchGet*",
-              "dynamodb:DescribeStream",
-              "dynamodb:DescribeTable",
-              "dynamodb:Get*",
-              "dynamodb:Query",
-              "dynamodb:Scan",
-              "dynamodb:BatchWrite*",
-              "dynamodb:CreateTable",
-              "dynamodb:Delete*",
-              "dynamodb:Update*",
-              "dynamodb:PutItem"
-          ],
-          "Resource": "${aws_dynamodb_table.startup_sample_table.arn}"
-        }
-    ]
-  }
-  )
-}
-
-## TODO: Document this
-
 resource "aws_iam_role_policy" "dynamodb_organizations_table_role_policy" {
   name = "dynamodb_organizations_table_role_policy"
   role = aws_iam_role.organizations_api_container_role.id
@@ -185,5 +153,3 @@ resource "aws_iam_role_policy" "dynamodb_organizations_table_role_policy" {
     }
   )
 }
-
-## END TODO

--- a/terraform-prod/infrastructure/db.tf
+++ b/terraform-prod/infrastructure/db.tf
@@ -1,27 +1,3 @@
-
-resource "aws_dynamodb_table" "startup_sample_table" {
-  name           = var.db_name
-  hash_key       = "pid"
-  range_key      = "createdAt"
-  read_capacity  = 1
-  write_capacity = 1
-
-  attribute {
-    name = "pid"
-    type = "S"
-  }
-
-  attribute {
-    name = "createdAt"
-    type = "S"
-  }
-
-  tags = local.common_tags
-}
-
-
-## TODO: Document this.
-
 resource "aws_dynamodb_table" "organization_table" {
   name           = "Organization"
   hash_key       = "id"
@@ -34,5 +10,3 @@ resource "aws_dynamodb_table" "organization_table" {
   }
 
 }
-
-## END TODO

--- a/terraform-prod/infrastructure/roles.tf
+++ b/terraform-prod/infrastructure/roles.tf
@@ -123,39 +123,6 @@ resource "aws_iam_role_policy" "ssp_bucket_policy" {
   EOF
 }
 
-
-resource "aws_iam_role_policy" "dynamodb_sample_table_role_policy" {
-  name = "dynamodb_sample_table_role_policy"
-  role = aws_iam_role.organizations_api_container_role.id
-
-  policy = jsonencode(
-  {
-    "Version": "2012-10-17",
-    "Statement": [
-      {
-          "Effect": "Allow",
-          "Action": [
-              "dynamodb:BatchGet*",
-              "dynamodb:DescribeStream",
-              "dynamodb:DescribeTable",
-              "dynamodb:Get*",
-              "dynamodb:Query",
-              "dynamodb:Scan",
-              "dynamodb:BatchWrite*",
-              "dynamodb:CreateTable",
-              "dynamodb:Delete*",
-              "dynamodb:Update*",
-              "dynamodb:PutItem"
-          ],
-          "Resource": "${aws_dynamodb_table.startup_sample_table.arn}"
-        }
-    ]
-  }
-  )
-}
-
-## TODO: Document this
-
 resource "aws_iam_role_policy" "dynamodb_organizations_table_role_policy" {
   name = "dynamodb_organizations_table_role_policy"
   role = aws_iam_role.organizations_api_container_role.id
@@ -185,5 +152,3 @@ resource "aws_iam_role_policy" "dynamodb_organizations_table_role_policy" {
     }
   )
 }
-
-## END TODO

--- a/terraform-test/infrastructure/db.tf
+++ b/terraform-test/infrastructure/db.tf
@@ -1,27 +1,3 @@
-
-resource "aws_dynamodb_table" "startup_sample_table" {
-  name           = var.db_name
-  hash_key       = "pid"
-  range_key      = "createdAt"
-  read_capacity  = 1
-  write_capacity = 1
-
-  attribute {
-    name = "pid"
-    type = "S"
-  }
-
-  attribute {
-    name = "createdAt"
-    type = "S"
-  }
-
-  tags = local.common_tags
-}
-
-
-## TODO: Document this.
-
 resource "aws_dynamodb_table" "organization_table" {
   name           = "Organization"
   hash_key       = "id"
@@ -34,5 +10,3 @@ resource "aws_dynamodb_table" "organization_table" {
   }
 
 }
-
-## END TODO

--- a/terraform-test/infrastructure/roles.tf
+++ b/terraform-test/infrastructure/roles.tf
@@ -123,39 +123,6 @@ resource "aws_iam_role_policy" "ssp_bucket_policy" {
   EOF
 }
 
-
-resource "aws_iam_role_policy" "dynamodb_sample_table_role_policy" {
-  name = "dynamodb_sample_table_role_policy"
-  role = aws_iam_role.organizations_api_container_role.id
-
-  policy = jsonencode(
-  {
-    "Version": "2012-10-17",
-    "Statement": [
-      {
-          "Effect": "Allow",
-          "Action": [
-              "dynamodb:BatchGet*",
-              "dynamodb:DescribeStream",
-              "dynamodb:DescribeTable",
-              "dynamodb:Get*",
-              "dynamodb:Query",
-              "dynamodb:Scan",
-              "dynamodb:BatchWrite*",
-              "dynamodb:CreateTable",
-              "dynamodb:Delete*",
-              "dynamodb:Update*",
-              "dynamodb:PutItem"
-          ],
-          "Resource": "${aws_dynamodb_table.startup_sample_table.arn}"
-        }
-    ]
-  }
-  )
-}
-
-## TODO: Document this
-
 resource "aws_iam_role_policy" "dynamodb_organizations_table_role_policy" {
   name = "dynamodb_organizations_table_role_policy"
   role = aws_iam_role.organizations_api_container_role.id
@@ -185,5 +152,3 @@ resource "aws_iam_role_policy" "dynamodb_organizations_table_role_policy" {
     }
   )
 }
-
-## END TODO


### PR DESCRIPTION
Add ability to delete orgs (for UMS test cleanup)
Sort organizations on backend
Cleanup terraform config files - delete sample tables and sample_table role policies

Unit tests for deleting orgs will be added as part of next PR, where I update integration tests to match current DB schema.