### PR TITLE
update app image uri to new aws environment

### DIFF
--- a/terraform-dev/main.tf
+++ b/terraform-dev/main.tf
@@ -3,9 +3,9 @@ locals {
   #  tfc_organization = "bcgov"
   #  project          = get_env("LICENSE_PLATE")
   #  environment      = reverse(split("/", get_terragrunt_dir()))[0]
-  #  app_image        = "646101433301.dkr.ecr.ca-central-1.amazonaws.com/ssp/sha256:36bf8b4342d35f4aa242e0d440f6edcfbed98bfe703a8a35d5f745f674135788"
-  #  app_image        = "646101433301.dkr.ecr.ca-central-1.amazonaws.com/ssp:e7757cf7bf4bb3c593a172ef77d1c19186433ac6"
-  app_image = "646101433301.dkr.ecr.ca-central-1.amazonaws.com/ssp:version1.0.0"
+  #  app_image        = "003664705641.dkr.ecr.ca-central-1.amazonaws.com/ssp/sha256:36bf8b4342d35f4aa242e0d440f6edcfbed98bfe703a8a35d5f745f674135788"
+  #  app_image        = "003664705641.dkr.ecr.ca-central-1.amazonaws.com/ssp:e7757cf7bf4bb3c593a172ef77d1c19186433ac6"
+  app_image = "003664705641.dkr.ecr.ca-central-1.amazonaws.com/ssp:version1.0.0"
 }
 
 variable "environment" {

--- a/terraform-prod/main.tf
+++ b/terraform-prod/main.tf
@@ -3,9 +3,9 @@ locals {
   #  tfc_organization = "bcgov"
   #  project          = get_env("LICENSE_PLATE")
   #  environment      = reverse(split("/", get_terragrunt_dir()))[0]
-  #  app_image        = "646101433301.dkr.ecr.ca-central-1.amazonaws.com/ssp/sha256:36bf8b4342d35f4aa242e0d440f6edcfbed98bfe703a8a35d5f745f674135788"
-  #  app_image        = "646101433301.dkr.ecr.ca-central-1.amazonaws.com/ssp:e7757cf7bf4bb3c593a172ef77d1c19186433ac6"
-  app_image = "646101433301.dkr.ecr.ca-central-1.amazonaws.com/ssp:latest"
+  #  app_image        = "003664705641.dkr.ecr.ca-central-1.amazonaws.com/ssp/sha256:36bf8b4342d35f4aa242e0d440f6edcfbed98bfe703a8a35d5f745f674135788"
+  #  app_image        = "003664705641.dkr.ecr.ca-central-1.amazonaws.com/ssp:e7757cf7bf4bb3c593a172ef77d1c19186433ac6"
+  app_image = "003664705641.dkr.ecr.ca-central-1.amazonaws.com/ssp:version1.0.0"
 }
 
 variable "environment" {

--- a/terraform-test/main.tf
+++ b/terraform-test/main.tf
@@ -3,9 +3,9 @@ locals {
   #  tfc_organization = "bcgov"
   #  project          = get_env("LICENSE_PLATE")
   #  environment      = reverse(split("/", get_terragrunt_dir()))[0]
-  #  app_image        = "646101433301.dkr.ecr.ca-central-1.amazonaws.com/ssp/sha256:36bf8b4342d35f4aa242e0d440f6edcfbed98bfe703a8a35d5f745f674135788"
-  #  app_image        = "646101433301.dkr.ecr.ca-central-1.amazonaws.com/ssp:e7757cf7bf4bb3c593a172ef77d1c19186433ac6"
-  app_image = "646101433301.dkr.ecr.ca-central-1.amazonaws.com/ssp:version1.0.0"
+  #  app_image        = "003664705641.dkr.ecr.ca-central-1.amazonaws.com/ssp/sha256:36bf8b4342d35f4aa242e0d440f6edcfbed98bfe703a8a35d5f745f674135788"
+  #  app_image        = "003664705641.dkr.ecr.ca-central-1.amazonaws.com/ssp:e7757cf7bf4bb3c593a172ef77d1c19186433ac6"
+  app_image = "003664705641.dkr.ecr.ca-central-1.amazonaws.com/ssp:version1.0.0"
 }
 
 variable "environment" {


### PR DESCRIPTION
Updating organizations-api image uri, to point to new `tools` environment instead of `sandbox` which is getting deprecated