### PR TITLE
update cpu and memory on test env

### DIFF
--- a/terraform-test/infrastructure/variables.tf
+++ b/terraform-test/infrastructure/variables.tf
@@ -64,12 +64,12 @@ variable "health_check_path" {
 
 variable "fargate_cpu" {
   description = "Fargate instance CPU units to provision (1 vCPU = 1024 CPU units)"
-  default     = 512
+  default     = 256
 }
 
 variable "fargate_memory" {
   description = "Fargate instance memory to provision (in MiB)"
-  default     = 1024
+  default     = 512
 }
 
 variable "db_name" {


### PR DESCRIPTION
ORG-API current resource utilization on TEST environment:

ECS task on dev env has .5 vCPU and 1GB memory provisioned
max cpu utilization: 13.5%
max memory utilization: 18.1%

Updating vCPU to 0.25 (256 CPU units) and Memory to 512MB