### PR TITLE
migrate-terraform state-files-to-s3

### DIFF
--- a/terraform-dev/infrastructure/roles.tf
+++ b/terraform-dev/infrastructure/roles.tf
@@ -155,8 +155,8 @@ EOF
             ]
             Effect = "Allow"
             Resource = [
-              "arn:aws:s3:::upload-bucket-mighty-duck",
-              "arn:aws:s3:::upload-bucket-mighty-duck/*",
+              "arn:aws:s3:::upload-bucket-decent-duck",
+              "arn:aws:s3:::upload-bucket-decent-duck/*",
               "arn:aws:kms:*:750307557100:key/*",
             ]
           },

--- a/terraform-dev/main.tf
+++ b/terraform-dev/main.tf
@@ -14,12 +14,12 @@ variable "environment" {
 }
 
 terraform {
-  backend "remote" {
-    hostname     = "app.terraform.io"
-    organization = "bcgov"
-    workspaces {
-      name = "cey5wq-dev"
-    }
+  backend "s3" {
+    bucket         = "terraform-remote-state-cey5wq-dev"
+    key            = "org-api-dev-tfstate"
+    region         = "ca-central-1"
+    dynamodb_table = "terraform-remote-state-lock-cey5wq"
+    encrypt        = true
   }
 }
 

--- a/terraform-prod/main.tf
+++ b/terraform-prod/main.tf
@@ -14,12 +14,12 @@ variable "environment" {
 }
 
 terraform {
-  backend "remote" {
-    hostname     = "app.terraform.io"
-    organization = "bcgov"
-    workspaces {
-      name = "cey5wq-prod"
-    }
+  backend "s3" {
+    bucket         = "terraform-remote-state-cey5wq-prod"
+    key            = "org-api-prod-tfstate"
+    region         = "ca-central-1"
+    dynamodb_table = "terraform-remote-state-lock-cey5wq"
+    encrypt        = true
   }
 }
 

--- a/terraform-test/main.tf
+++ b/terraform-test/main.tf
@@ -14,12 +14,12 @@ variable "environment" {
 }
 
 terraform {
-  backend "remote" {
-    hostname     = "app.terraform.io"
-    organization = "bcgov"
-    workspaces {
-      name = "cey5wq-test"
-    }
+  backend "s3" {
+    bucket         = "terraform-remote-state-cey5wq-test"
+    key            = "org-api-test-tfstate"
+    region         = "ca-central-1"
+    dynamodb_table = "terraform-remote-state-lock-cey5wq"
+    encrypt        = true
   }
 }
 


### PR DESCRIPTION
Renaming the s3 bucket name to follow the external changes made in the dev environment.
Reflecting the terraform state migration in configuration files. The Terraform backend was migrated from a Terraform cloud to dev/test/prod environments.