### PR TITLE
update-aws-provider-config

### DIFF
--- a/terraform-dev/main.tf
+++ b/terraform-dev/main.tf
@@ -25,11 +25,6 @@ terraform {
 
 provider "aws" {
   region = var.aws_region
-  assume_role {
-    # Copied from IAM console
-    role_arn = "arn:aws:iam::750307557100:role/BCGOV_dev_Automation_Admin_Role"
-    # role_arn = "arn:aws:iam::$${var.target_aws_account_id}:role/BCGOV_$${var.target_env}_Automation_Admin_Role"
-  }
 }
 
 variable "aws_region" {

--- a/terraform-prod/main.tf
+++ b/terraform-prod/main.tf
@@ -25,11 +25,6 @@ terraform {
 
 provider "aws" {
   region = var.aws_region
-  assume_role {
-    # Copied from IAM console
-    role_arn = "arn:aws:iam::978713299899:role/BCGOV_prod_Automation_Admin_Role"
-    # role_arn = "arn:aws:iam::$${var.target_aws_account_id}:role/BCGOV_$${var.target_env}_Automation_Admin_Role"
-  }
 }
 
 variable "aws_region" {

--- a/terraform-test/main.tf
+++ b/terraform-test/main.tf
@@ -25,11 +25,6 @@ terraform {
 
 provider "aws" {
   region = var.aws_region
-  assume_role {
-    # Copied from IAM console
-    role_arn = "arn:aws:iam::787619965950:role/BCGOV_test_Automation_Admin_Role"
-    # role_arn = "arn:aws:iam::$${var.target_aws_account_id}:role/BCGOV_$${var.target_env}_Automation_Admin_Role"
-  }
 }
 
 variable "aws_region" {


### PR DESCRIPTION
Removing the assume_role directive, as the role is already assumed when authenticating with GitHub OIDC.